### PR TITLE
RMET-324 - TouchId Plugin (FaceId with password not working)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-touchid",
-  "version": "0.4.0-OS1",
+  "version": "0.4.0-OS2",
   "author": "Lee Crossley <leee@hotmail.co.uk> (http://ilee.co.uk/)",
   "description": "Cordova Plugin to leverage the iOS local authentication framework to allow in-app user authentication using Touch ID.",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-touchid" version="0.4.0-OS1">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" id="cordova-plugin-touchid" version="0.4.0-OS2">
     <name>Touch ID</name>
     <author>Lee Crossley (http://ilee.co.uk/)</author>
     <description>Cordova Plugin to leverage the iOS local authentication framework to allow in-app user authentication using Touch ID.</description>

--- a/src/ios/TouchID.m
+++ b/src/ios/TouchID.m
@@ -20,9 +20,9 @@
         LAContext *laContext = [[LAContext alloc] init];
         NSError *authError = nil;
 
-        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&authError])
         {
-            [laContext evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:text reply:^(BOOL success, NSError *error)
+            [laContext evaluatePolicy:LAPolicyDeviceOwnerAuthentication localizedReason:text reply:^(BOOL success, NSError *error)
              {
                  if (success)
                  {
@@ -87,7 +87,7 @@
         LAContext *laContext = [[LAContext alloc] init];
         NSError *authError = nil;
 
-        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&authError])
+        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&authError])
         {
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         }
@@ -114,7 +114,7 @@
         //No biometry
         int biometryType = -1;
         
-        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil]) {
+        if ([laContext canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:nil]) {
             if (@available(iOS 11.0, *)) {
                 if (laContext.biometryType == LABiometryTypeFaceID) {
                     //FaceID


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Updated LAPolicy from LAPolicyDeviceOwnerAuthenticationWithBiometrics  to LAPolicyDeviceOwnerAuthentication

LAPolicyDeviceOwnerAuthenticationWithBiometrics was not presenting passcode view after failed authentication with face ID

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Closes the issue: https://outsystemsrd.atlassian.net/browse/RMET-324

<!--- Why is this change required? What problem does it solve? -->
Change required to fix authentication process
 
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Executed the P0s tests of the test plan
<!--- Include details of your test environment if relevant -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly